### PR TITLE
UI tweaks to fuel/silo display

### DIFF
--- a/fe/css/app.css
+++ b/fe/css/app.css
@@ -28,3 +28,17 @@ tr[ng-click] {
 .btn-dropdown {
     width: 100px;
 }
+
+.vertical-meter {
+    width: 30px;
+    height: 7px;
+    transform: rotate(-90deg);
+    margin-left: -5px;
+    margin-right: -5px;
+    vertical-align: middle;
+}
+
+.silo-numbers {
+    display: inline-block;
+    vertical-align: middle;
+}

--- a/fe/js/pos-controllers.js
+++ b/fe/js/pos-controllers.js
@@ -62,8 +62,13 @@ function processTower(tower) {
             if (siloHours < minHours) {
                 minHours = siloHours;
             }
-            silo.volume = silo.input ? silo.capacity - silo.qty * silo.content_size : silo.qty * silo.content_size;
-            silo.volume = Math.round(silo.volume / 100) / 10;
+            silo.qty_free = silo.capacity / silo.content_size - silo.qty;
+            silo.qty_free = Math.round(silo.qty_free);
+            silo.volume_filled = silo.qty * silo.content_size;
+            silo.volume_free = silo.capacity - silo.volume_filled;
+            silo.volume_filled = Math.round(silo.volume_filled / 100) / 10;
+            silo.volume_free = Math.round(silo.volume_free / 100) / 10;
+            silo.volume = silo.input ? silo.volume_free : silo.volume_filled;
             if (silo.input) tower.input_volume += silo.volume;
             else tower.output_volume += silo.volume;
         } else {
@@ -77,9 +82,13 @@ function processTower(tower) {
         tower.errors.push('Tower has ' + tower.empty_guns + ' guns without ammo.');
     }
     tower.hours_remaining = minHours;
-    tower.fuel_volume = tower.fuel_bay_capacity - tower.fuel_qty * 5;
-    tower.fuel_volume = Math.round(tower.fuel_volume / 100) / 10;
-    tower.input_volume += tower.fuel_volume;
+    tower.fuel_qty_free = tower.fuel_bay_capacity / 5 - tower.fuel_qty;
+    tower.fuel_volume_filled = tower.fuel_qty * 5;
+    tower.fuel_volume_free = tower.fuel_bay_capacity - tower.fuel_volume_filled;
+    tower.fuel_volume_filled = Math.round(tower.fuel_volume_filled / 100) / 10;
+    tower.fuel_volume_free = Math.round(tower.fuel_volume_free / 100) / 10;
+    tower.fuel_volume = tower.fuel_volume_free;
+    tower.input_volume += tower.fuel_volume_free;
     tower.input_volume = Math.round(tower.input_volume * 10) / 10;
 }
 

--- a/fe/templates/towers.html
+++ b/fe/templates/towers.html
@@ -36,9 +36,26 @@
 <div class="row row-padded" ng-repeat="tower in towers |orderBy:selected_sort.predicate">
     <h3><a href="/ofsoundposes/#/towers/{{ tower.pos_id }}">{{ tower.system_name }} {{ tower.location }} - {{ tower.pos_name }}</a></h3>
     <h4>{{ tower.owner_name }} ({{ tower.corp_ticker }}) - {{ tower.pos_type_name }} - <span class="text-capitalize">{{ tower.status }}</span></h4>
-    <div class="col-sm-2 col-xs-4 {{ tower.fuel_class }}"><img title="{{ tower.fuel_type_name }}" ng-src="https://image.eveonline.com/Type/{{ tower.fuel_type_id }}_32.png"> {{ tower.fuel_volume }}km<sup>3</sup> <i class="fa fa-arrow-down"></i> {{ tower.fuel_time }}</div>
-    <div class="col-sm-2 col-xs-4 {{ silo.silo_class }}" ng-repeat="silo in tower.silos |orderBy:'content_type_name'">
-        <img title="{{ silo.content_type_name }}" ng-src="https://image.eveonline.com/Type/{{ silo.content_type_id }}_32.png"> <span ng-if="silo.volume">{{ silo.volume }}km<sup>3</sup></span> <i ng-if="silo.input" class="fa fa-arrow-down"></i><i ng-if="!silo.input" class="fa fa-arrow-up"></i> {{ silo.silo_time }}
+    <div class="col-lg-3 col-md-4 col-sm-5 col-xs-6 {{ tower.fuel_class }}">
+        <img title="{{ tower.fuel_type_name }}" ng-src="https://image.eveonline.com/Type/{{ tower.fuel_type_id }}_32.png">
+        <div class="silo-numbers">
+            <span>Free: {{ tower.fuel_qty_free }} / {{ tower.fuel_volume_free }}km<sup>3</sup></span><br/>
+            <span>Filled: {{ tower.fuel_qty }} / {{ tower.fuel_volume_filled }}km<sup>3</sup></span><br/>
+        </div>
+        <meter class="vertical-meter" max="{{tower.fuel_bay_capacity}}" value="{{tower.fuel_volume_filled * 1000 }}"></meter>
+        <i class="fa fa-arrow-down"></i>
+        {{ tower.fuel_time }}
+    </div>
+    <div class="col-lg-3 col-md-4 col-sm-5 col-xs-6 {{ silo.silo_class }}" ng-repeat="silo in tower.silos |orderBy:'content_type_name'">
+        <img title="{{ silo.content_type_name }}" ng-src="https://image.eveonline.com/Type/{{ silo.content_type_id }}_32.png">
+        <div class="silo-numbers">
+            <span>Free: {{ silo.qty_free }} / {{ silo.volume_free }}km<sup>3</sup></span><br/>
+            <span>Filled: {{ silo.qty }} / {{ silo.volume_filled }}km<sup>3</sup></span><br/>
+        </div>
+        <meter class="vertical-meter" max="{{silo.capacity}}" value="{{silo.volume_filled * 1000 }}"></meter>
+        <i ng-if="silo.input" class="fa fa-arrow-down"></i>
+        <i ng-if="!silo.input" class="fa fa-arrow-up"></i>
+        {{ silo.silo_time }}
     </div>
     <div class="col-xs-12">&nbsp;</div>
     <div class="col-xs-12">Total volume to fill inputs: {{ tower.input_volume }}km<sup>3</sup></div>


### PR DESCRIPTION
It was confusing that sometimes the volumes displayed were the volume of
the contents, and sometimes the volume of the free space, depending on
whether the silo was an input or output. This makes the meaning
consistent by just showing both. It also includes quantities in addition
to volumes, which is helpful when e.g. shift-dragging from a stack into
your hauler.

The meter bridges the conceptual gap between the free/filled numbers and
the input/output arrow indicator. Without this, it would be easy to
think that a down (input) arrow indicates quantity being transfered from
the upper (free) line to the lower (filled) line, but this is the
opposite of reality. The meter matches nicely both with the numbers to
the left (the upper line describes the upper/empty part of the meter)
and the right (a down arrow indicates that the meter is falling).

I considered trying to fit a percentage indicator in somewhere, but I
don't think it would provide much value. The meter gives a rough
indication, and who cares about the exact percentage?

The meter css feels a bit sketch (rotation + negative margin to offset
the still-applied width attribute). Maybe it would be better to roll our
own meter UI with colored divs. But this works well enough in both
Chrome and Firefox that it's probably fine (though they seem to treat
the combination of rotation & margin differently).
